### PR TITLE
Make `gversion` run before "new" `compileKotlin` task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,7 @@ wpi.java.configureExecutableTasks(jar)
 wpi.java.configureTestTasks(test)
 
 // Create version file
-project.compileJava.dependsOn(createVersionFile)
+project.compileKotlin.dependsOn(createVersionFile)
 gversion {
     srcDir       = "src/main/kotlin/"
     classPackage = "frc.robot"

--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,7 @@ wpi.java.configureTestTasks(test)
 
 // Create version file
 project.compileKotlin.dependsOn(createVersionFile)
+project.compileJava.dependsOn(createVersionFile)
 gversion {
     srcDir       = "src/main/kotlin/"
     classPackage = "frc.robot"


### PR DESCRIPTION
The `compileJava` task doesn't exist anymore, so it seems then `gversion` never worked in Kotlin, eh? Which also means the commits written in the log files are not true?